### PR TITLE
[WIP] adds option to specify response type

### DIFF
--- a/src/FetchREST.ts
+++ b/src/FetchREST.ts
@@ -25,20 +25,21 @@ export type GlobalRequestOptions = RequestOptions & {
 };
 export type GlobalRequestOptionsGetter = () => GlobalRequestOptions;
 
-export type Middleware = (response: Promise<Response>) => Promise<Response>;
+export type Middleware<T> = (response: Promise<Response>) => Promise<T>;
 
-export default class FetchREST {
+export default class FetchREST<TransformedResponse = Response> {
   private globalOptions: GlobalRequestOptions | GlobalRequestOptionsGetter;
-  private requestMiddleware: Middleware;
+  private requestMiddleware: Middleware<TransformedResponse>;
   private abortControllers: {
     [token: string]: AbortController[];
   } = {};
 
   constructor(options: GlobalRequestOptions | GlobalRequestOptionsGetter) {
     this.globalOptions = options;
+    this.requestMiddleware = request => request;
   }
 
-  middleware(middleware: Middleware) {
+  middleware(middleware: Middleware<TransformedResponse>) {
     this.requestMiddleware = middleware;
   }
 
@@ -185,10 +186,6 @@ export default class FetchREST {
         return {...resData, body: finalBody};
       },
     );
-
-    if (!this.requestMiddleware) {
-      return baseRequest;
-    }
 
     return this.requestMiddleware(baseRequest);
   }

--- a/src/tests/FetchREST.test.ts
+++ b/src/tests/FetchREST.test.ts
@@ -808,7 +808,11 @@ describe('middleware', () => {
       status: 200,
     });
 
-    const fetchRest = new FetchREST({
+    interface ResponseWithDate extends Response {
+      date: string;
+    }
+
+    const fetchRest = new FetchREST<ResponseWithDate>({
       apiUrl: 'https://testapi.com',
     });
 
@@ -816,9 +820,7 @@ describe('middleware', () => {
       request.then(response => ({...response, date: '14-04-2017'})),
     );
 
-    const {date} = (await fetchRest.post('/users')) as Response & {
-      date: string;
-    };
+    const {date} = await fetchRest.post('/users');
     expect(date).toBe('14-04-2017');
   });
 


### PR DESCRIPTION
fixes #22 

**Problem**
Currently when you modify a response using the `middleware` method you have to locally cast to the new response type.

```ts
type ResponseWithDate = Response & {
  date: string;
};

const fetchRest = new FetchREST({
  apiUrl: 'https://testapi.com',
});

fetchRest.middleware(request =>
  request.then(response => ({...response, date: '14-04-2017'})),
);

const {date} = (await fetchRest.post('/users')) as ResponseWithDate;
const {date} = (await fetchRest.get('/users')) as ResponseWithDate;
```

**Solution 1: Declare new response type on the middleware method**
I'm still not sure how I feel about this solution. It might be the best one though although this way the type defined on the middleware influences how the entire class works which seems iffy. The problem also is that the type comes in through a child method and needs to make changes to a class instance which I'm not sure is possible?

The upside of this solution is that you can enforce that at least the type that is returned from the middleware is of the right type. The biggest con here is that responses need to be of this type _going forward_ and past responses need to _keep their old type_ which I don't think is possible in TypeScript today as that would require actual JS.

```ts
type ResponseWithDate = Response & {
  date: string;
};

const fetchRest = new FetchREST({
  apiUrl: 'https://testapi.com',
});

fetchRest.middleware<ResponseWithDate>(request =>
  request.then(response => ({...response, date: '14-04-2017'})),
);

const {date} = await fetchRest.post('/users');
const {date} = await fetchRest.get('/users');
```

**Solution 2: Class type and middleware**
The problem is that you can define a type on the class but if you have to call a separate method to transform the response there is no guarantee it will actually be transformed into that type.
```ts
type ResponseWithDate = Response & {
  date: string;
};

const fetchRest = new FetchREST<ResponseWithDate>({
  apiUrl: 'https://testapi.com',
});

fetchRest.middleware(request =>
  request.then(response => ({...response, date: '14-04-2017'})),
);

const {date} = await fetchRest.post('/users');
const {date} = await fetchRest.get('/users');
```

**Solution 3: Response transformer**
The problem here is that even if you define a type if the transformer argument is not required there is no guarantee that the response will actually get transformed.

```ts
type ResponseWithDate = Response & {
  date: string;
};

const fetchRest = new FetchREST<ResponseWithDate>({
  apiUrl: 'https://testapi.com',
}, response => ({...response, date: '14-04-2017'}));

const {date} = await fetchRest.post('/users');
const {date} = await fetchRest.get('/users');
```

That's why the only real solution would be to require the second argument. Or at least if a custom type is defined but that condition is impossible to make as TypeScript has no control over actual JS. So you can't say something like: if a custom type is required then require this argument.

This means you end up having to always require the argument. All you can do is provide an easy way to define it if someone doesn't need it. Using for example a static default.

```ts
const fetchRest = new FetchREST({
  apiUrl: 'https://testapi.com',
}, FetchREST.defaultTransformer);

const {body} = await fetchRest.post('/users');
const {body} = await fetchRest.get('/users');
```

The biggest pro with this solution is definitely that its the cleanest. An instance of the class should have a single return type defined. The problem however is that this breaks the current API, unless you would make this a different class.

```ts
type ResponseWithDate = Response & {
  date: string;
};

const fetchRest = new TransformingFetchREST<ResponseWithDate>({
  apiUrl: 'https://testapi.com',
}, response => ({...response, date: '14-04-2017'}));

const {date} = await fetchRest.post('/users');
const {date} = await fetchRest.get('/users');
```
